### PR TITLE
Fix docs site paths and copy bootstrap into GH pages site

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -219,6 +219,9 @@
         "astro": "^6.0.1",
         "sharp": "^0.34.2",
       },
+      "devDependencies": {
+        "@types/bun": "^1.3.12",
+      },
     },
     "packages/downloader": {
       "name": "@dotfiles/downloader",
@@ -2391,6 +2394,8 @@
 
     "@astrojs/markdown-remark/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
+    "@dotfiles/docs/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.35", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@17.67.0", "", { "dependencies": { "@jsonjoy.com/base64": "17.67.0", "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0", "@jsonjoy.com/json-pointer": "17.67.0", "@jsonjoy.com/util": "17.67.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w=="],
@@ -2478,6 +2483,8 @@
     "@astrojs/markdown-remark/shiki/@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
 
     "@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@dotfiles/docs/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,5 +14,8 @@
     "@astrojs/starlight": "^0.38.3",
     "astro": "^6.0.1",
     "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.12"
   }
 }

--- a/packages/docs/sync.ts
+++ b/packages/docs/sync.ts
@@ -1,9 +1,11 @@
-import { $ } from "bun";
 import fs from "node:fs";
 import path from "node:path";
+import { $ } from "bun";
 
 const sourceDir = path.resolve(import.meta.dir, "../../.agents/skills/dotfiles");
 const destDir = path.resolve(import.meta.dir, "src/content/docs");
+const installerSourcePath = path.resolve(import.meta.dir, "../../scripts/managed-installer/install.sh");
+const installerDestPath = path.resolve(import.meta.dir, "public/install.sh");
 
 // Clean and recreate destination
 await $`rm -rf ${destDir} || true`.quiet();
@@ -11,7 +13,10 @@ await $`mkdir -p ${destDir}`.quiet();
 await $`touch ${destDir}/.gitkeep`.quiet();
 
 // Copy all files from skills references
-await $`cp -R ${sourceDir}/references/ ${destDir}/`.quiet();
+await $`cp -R ${sourceDir}/references/. ${destDir}/`.quiet();
+
+// Copy the installer
+await $`cp ${installerSourcePath} ${installerDestPath}`.quiet();
 
 // Copy the root README.md to be the index page
 const rootReadmePath = path.resolve(import.meta.dir, "../../README.md");


### PR DESCRIPTION
Hey - I took a look at the docs site weirdness and the actual fix ended up being pretty small.

## What changed

- `packages/docs/sync.ts` now copies `references/.` into the docs content directory instead of copying the `references` folder itself
- the managed installer script now gets copied into `packages/docs/public/install.sh`
- I also added `@types/bun` to the docs package since this script uses Bun globals and TypeScript was unhappy without it

## Why this fixes it

The main issue was that the docs sync step was relying on `cp -R` behavior that doesn't line up the same way across environments.

On my machine and yours (macOS), the copy ended up flattening the contents of `references/` into the docs root, which is what the site config expects.

In GitHub Actions (Linux), that same command produced routes under `/references/...`, so the build technically succeeded, but a bunch of the site links pointed at `/api-reference/...`, `/configuration/...`, etc. and those pages 404'd.

The installer problem was simpler: `install.sh` just wasn't being published into the docs artifact, so the bootstrap install URL 404'd too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for improved tooling support.
  * Updated installer script distribution in documentation package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->